### PR TITLE
fix(Gopkg.toml):override fsnotify due to dep ensure failure

### DIFF
--- a/api/Gopkg.toml
+++ b/api/Gopkg.toml
@@ -45,3 +45,7 @@
 [[constraint]]
   name = "github.com/onsi/ginkgo"
   version = "1.8.0"
+
+[[override]]
+  source = "https://github.com/fsnotify/fsnotify/archive/v1.4.7.tar.gz"
+  name = "gopkg.in/fsnotify.v1"


### PR DESCRIPTION
look here:
https://github.com/golang/dep/issues/1799